### PR TITLE
replace uint to wordcount_t for keil arm compiler

### DIFF
--- a/uECC.c
+++ b/uECC.c
@@ -1280,7 +1280,7 @@ static void omega_mult(uint32_t * RESTRICT p_result, uint32_t * RESTRICT p_right
 {
     /* Multiply by (2^9 + 2^8 + 2^7 + 2^6 + 2^4 + 1). */
     uint32_t l_carry = 0;
-    uint i;
+    wordcount_t i;
     for(i=0; i<uECC_WORDS; ++i)
     {
         uint64_t p = (uint64_t)0x3D1 * p_right[i] + l_carry;


### PR DESCRIPTION
Try to compile by keil arm compiler, but failed to find uint type. Seems wordcount_t is a better choice.
