### PR TITLE
Add methods to return values def'd at compile time

### DIFF
--- a/uECC.c
+++ b/uECC.c
@@ -2333,3 +2333,13 @@ int uECC_verify(const uint8_t p_publicKey[uECC_BYTES*2], const uint8_t p_hash[uE
     /* Accept only if v == r. */
     return (vli_cmp(rx, r) == 0);
 }
+
+int uECC_bytes()
+{
+    return uECC_BYTES;
+}
+
+int uECC_curve()
+{
+    return uECC_CURVE;
+}

--- a/uECC.h
+++ b/uECC.h
@@ -164,6 +164,26 @@ Returns 1 if the signature is valid, 0 if it is invalid.
 */
 int uECC_verify(const uint8_t p_publicKey[uECC_BYTES*2], const uint8_t p_hash[uECC_BYTES], const uint8_t p_signature[uECC_BYTES*2]);
 
+/* uECC_bytes() function.
+Return the value of uECC_BYTES. Helpful for foreign-interfaces to higher-level languages.
+
+Inputs:
+    (none)
+
+Returns the value of uECC_BYTES
+*/
+int uECC_bytes();
+
+/* uECC_curve() function.
+Return the value of uECC_CURVE. Helpful for foreign-interfaces to higher-level languages.
+
+Inputs:
+    (none)
+
+Returns the value of uECC_CURVE
+*/
+int uECC_curve();
+
 #ifdef __cplusplus
 } /* end of extern "C" */
 #endif


### PR DESCRIPTION
This will support higher-level languages interfacing with `micro-ecc`. For example, recently I was writing a foreign-function interface to `micro-ecc` via Haskell. I needed to allocate some memory but was unable to access the `uECC_BYTES` constant as it's defined at compile time.

This pull request is unsolicited so I understand if these methods are outside the scope of the project (or may result in compiled code being too large for embedded devices).

Just let me know!