### PR TITLE
Code now builds with SDCC for 8051

### DIFF
--- a/uECC.c
+++ b/uECC.c
@@ -2215,10 +2215,10 @@ int uECC_sign(const uint8_t p_privateKey[uECC_BYTES], const uint8_t p_hash[uECC_
     uECC_word_t *k2[2] = {l_tmp, s};
     EccPoint p;
     uECC_word_t l_tries = 0;
-    uECC_word_t l_carry;
     
     do
     {
+        uECC_word_t l_carry;
     repeat:
         if(!g_rng((uint8_t *)k, sizeof(k)) || (l_tries++ >= MAX_TRIES))
         {
@@ -2251,7 +2251,7 @@ int uECC_sign(const uint8_t p_privateKey[uECC_BYTES], const uint8_t p_hash[uECC_
         }
         
         /* make sure that we don't leak timing information about k. See http://eprint.iacr.org/2011/232.pdf */
-        uECC_word_t l_carry = vli_add(l_tmp, k, curve_n);
+        l_carry = vli_add(l_tmp, k, curve_n);
         vli_add(s, l_tmp, curve_n);
     
         /* p = k * G */
@@ -2317,7 +2317,6 @@ int uECC_verify(const uint8_t p_publicKey[uECC_BYTES*2], const uint8_t p_hash[uE
     uECC_word_t tx[uECC_WORDS];
     uECC_word_t ty[uECC_WORDS];
     uECC_word_t tz[uECC_WORDS];
-    uECC_word_t l_index;
     
     const EccPoint *l_points[4];
     const EccPoint *l_point;
@@ -2377,6 +2376,7 @@ int uECC_verify(const uint8_t p_publicKey[uECC_BYTES*2], const uint8_t p_hash[uE
 
     for(i = l_numBits - 2; i >= 0; --i)
     {
+        uECC_word_t l_index;
         EccPoint_double_jacobian(rx, ry, z);
         
         l_index = (!!vli_testBit(u1, i)) | ((!!vli_testBit(u2, i)) << 1);

--- a/uECC.h
+++ b/uECC.h
@@ -55,6 +55,12 @@ uECC_asm_fast  - Use GCC inline assembly optimized for maximum speed. */
 
 #define uECC_BYTES uECC_CONCAT(uECC_size_, uECC_CURVE)
 
+#if(__SDCC_mcs51)
+#define uECC_FPTR_FIXUP __reentrant
+#else //SDCC_mcs51
+#define uECC_FPTR_FIXUP
+#endif //SDCC_mcs51
+
 #ifdef __cplusplus
 extern "C"
 {
@@ -73,7 +79,7 @@ If you are building on another POSIX-compliant system that supports /dev/random 
 you can define uECC_POSIX to use the predefined RNG. For embedded platforms there is no predefined
 RNG function; you must provide your own.
 */
-typedef int (*uECC_RNG_Function)(uint8_t *p_dest, unsigned p_size);
+typedef int (*uECC_RNG_Function)(uint8_t *p_dest, unsigned p_size) uECC_FPTR_FIXUP;
 
 /* uECC_set_rng() function.
 Set the function that will be used to generate random bytes. The RNG function should

--- a/uECC.h
+++ b/uECC.h
@@ -55,12 +55,6 @@ uECC_asm_fast  - Use GCC inline assembly optimized for maximum speed. */
 
 #define uECC_BYTES uECC_CONCAT(uECC_size_, uECC_CURVE)
 
-#if(__SDCC_mcs51)
-#define uECC_FPTR_FIXUP __reentrant
-#else //SDCC_mcs51
-#define uECC_FPTR_FIXUP
-#endif //SDCC_mcs51
-
 #ifdef __cplusplus
 extern "C"
 {
@@ -79,7 +73,7 @@ If you are building on another POSIX-compliant system that supports /dev/random 
 you can define uECC_POSIX to use the predefined RNG. For embedded platforms there is no predefined
 RNG function; you must provide your own.
 */
-typedef int (*uECC_RNG_Function)(uint8_t *p_dest, unsigned p_size) uECC_FPTR_FIXUP;
+typedef int (*uECC_RNG_Function)(uint8_t *p_dest, unsigned p_size);
 
 /* uECC_set_rng() function.
 Set the function that will be used to generate random bytes. The RNG function should


### PR DESCRIPTION
Configured with
uECC_CURVE=uECC_secp160r1
uECC_PLATFORM=uECC_arch_other
uECC_ASM=uECC_asm_none
uECC_WORD_SIZE=1

The problem is that sdcc doesn't really support most of C99 -- like variable declarations in various places.
Also often requires function pointers to be marked __reentrant.