### PR TITLE
Added compile time checks

### DIFF
--- a/asm_arm.inc
+++ b/asm_arm.inc
@@ -1247,6 +1247,7 @@ static void vli_mult(uint32_t *result, const uint32_t *left, const uint32_t *rig
 #define asm_mult 1
 #endif /* (uECC_WORDS == 8) */
 
+#if uECC_SQUARE_FUNC
 #if (uECC_WORDS == 5)
 static void vli_square(uint32_t *result, const uint32_t *left) {
     register uint32_t *r0 __asm__("r0") = result;
@@ -2030,6 +2031,7 @@ static void vli_square(uint32_t *result, const uint32_t *left) {
 }
 #define asm_square 1
 #endif /* (uECC_WORDS == 8) */
+#endif /* uECC_SQUARE_FUNC */
 
 #endif /* (uECC_PLATFORM != uECC_arm_thumb) */
 #endif /* (uECC_ASM == uECC_asm_fast) */

--- a/uECC.c
+++ b/uECC.c
@@ -623,7 +623,7 @@ static uECC_word_t vli_sub(uECC_word_t *result, const uECC_word_t *left, const u
 }
 #endif
 
-#if (!asm_mult || !asm_square || uECC_CURVE == uECC_secp256k1)
+#if (!asm_mult || (uECC_SQUARE_FUNC && !asm_square) || uECC_CURVE == uECC_secp256k1)
 static void muladd(uECC_word_t a,
                    uECC_word_t b,
                    uECC_word_t *r0,


### PR DESCRIPTION
Added compile time checks to skip vli_square() and muladd() functions when they are not used