### PR TITLE
Fix a logic error in deterministic PRNG with buffer overrun issue

### DIFF
--- a/uECC.c
+++ b/uECC.c
@@ -2629,9 +2629,15 @@ int uECC_sign_deterministic(const uint8_t private_key[uECC_BYTES],
                 T_ptr[T_bytes] = V[i];
             }
         }
-    #if (uECC_CURVE == uECC_secp160r1)
-        T[uECC_WORDS] &= 0x01;
+#if (uECC_CURVE == uECC_secp160r1)
+    #if (uECC_WORD_SIZE == 1)
+        T[uECC_N_WORDS - 1] &= 0x01;
+    #elif (uECC_WORD_SIZE == 4)
+        T[uECC_N_WORDS - 1] &= 0x00000001;
+    #elif (uECC_WORD_SIZE == 8)
+        T[uECC_N_WORDS - 1] &= 0x00000001ffffffff; // keep the lower 33 bits
     #endif
+#endif
     
         if (uECC_sign_with_k(private_key, message_hash, T, signature)) {
             return 1;


### PR DESCRIPTION
In `uECC_sign_deterministic`, when `uECC_WORD_SIZE` is 8, the array declaration for T becomes `uint64_t T[3];` and the following code

```c
    #if (uECC_CURVE == uECC_secp160r1)
        T[uECC_WORDS] &= 0x01;
    #endif
```

becomes

```c
        T[3] &= 0x01; // FIXME: access an array element outside its boundary?
```

I think that is not what we want (to keep only 161 pseudo-random bits so that 0 <= k <= 2^161-1) and the code in that case should be

```c
        T[2] &= 0x00000001ffffffff; // keep the lower 33 bits
```

The entire code block may be changed into something like this:

```c
#if (uECC_CURVE == uECC_secp160r1)
    #if (uECC_WORD_SIZE == 1)
        T[uECC_N_WORDS - 1] &= 0x01;
    #elif (uECC_WORD_SIZE == 4)
        T[uECC_N_WORDS - 1] &= 0x00000001;
    #elif (uECC_WORD_SIZE == 8)
        T[uECC_N_WORDS - 1] &= 0x00000001ffffffff;
    #endif
#endif
```