### PR TITLE
miscellaneous documentation and whitespace cleanups

### DIFF
--- a/test/test_ecdsa_deterministic.c.example
+++ b/test/test_ecdsa_deterministic.c.example
@@ -23,19 +23,19 @@ typedef struct SHA256_HashContext {
     SHA256_CTX ctx;
 } SHA256_HashContext;
 
-static void init_SHA256(uECC_HashContext *base) {
+static void init_SHA256(const uECC_HashContext *base) {
     SHA256_HashContext *context = (SHA256_HashContext *)base;
     SHA256_Init(&context->ctx);
 }
 
-static void update_SHA256(uECC_HashContext *base,
+static void update_SHA256(const uECC_HashContext *base,
                           const uint8_t *message,
                           unsigned message_size) {
     SHA256_HashContext *context = (SHA256_HashContext *)base;
     SHA256_Update(&context->ctx, message, message_size);
 }
 
-static void finish_SHA256(uECC_HashContext *base, uint8_t *hash_result) {
+static void finish_SHA256(const uECC_HashContext *base, uint8_t *hash_result) {
     SHA256_HashContext *context = (SHA256_HashContext *)base;
     SHA256_Final(hash_result, &context->ctx);
 }

--- a/test/test_ecdsa_deterministic.c.example
+++ b/test/test_ecdsa_deterministic.c.example
@@ -76,12 +76,12 @@ int main() {
             }
             memcpy(hash, public, sizeof(hash));
             
-            if (!uECC_sign_deterministic(private, hash, &ctx.uECC, sig, curves[c])) {
+            if (!uECC_sign_deterministic(private, hash, sizeof(hash), &ctx.uECC, sig, curves[c])) {
                 printf("uECC_sign() failed\n");
                 return 1;
             }
 
-            if (!uECC_verify(public, hash, sig, curves[c])) {
+            if (!uECC_verify(public, hash, sizeof(hash), sig, curves[c])) {
                 printf("uECC_verify() failed\n");
                 return 1;
             }

--- a/uECC.c
+++ b/uECC.c
@@ -1231,7 +1231,7 @@ int uECC_sign(const uint8_t *private_key,
 
 /* Compute an HMAC using K as a key (as in RFC 6979). Note that K is always
    the same size as the hash result size. */
-static void HMAC_init(uECC_HashContext *hash_context, const uint8_t *K) {
+static void HMAC_init(const uECC_HashContext *hash_context, const uint8_t *K) {
     uint8_t *pad = hash_context->tmp + 2 * hash_context->result_size;
     unsigned i;
     for (i = 0; i < hash_context->result_size; ++i)
@@ -1243,13 +1243,15 @@ static void HMAC_init(uECC_HashContext *hash_context, const uint8_t *K) {
     hash_context->update_hash(hash_context, pad, hash_context->block_size);
 }
 
-static void HMAC_update(uECC_HashContext *hash_context,
+static void HMAC_update(const uECC_HashContext *hash_context,
                         const uint8_t *message,
                         unsigned message_size) {
     hash_context->update_hash(hash_context, message, message_size);
 }
 
-static void HMAC_finish(uECC_HashContext *hash_context, const uint8_t *K, uint8_t *result) {
+static void HMAC_finish(const uECC_HashContext *hash_context,
+                        const uint8_t *K,
+                        uint8_t *result) {
     uint8_t *pad = hash_context->tmp + 2 * hash_context->result_size;
     unsigned i;
     for (i = 0; i < hash_context->result_size; ++i)
@@ -1266,7 +1268,7 @@ static void HMAC_finish(uECC_HashContext *hash_context, const uint8_t *K, uint8_
 }
 
 /* V = HMAC_K(V) */
-static void update_V(uECC_HashContext *hash_context, uint8_t *K, uint8_t *V) {
+static void update_V(const uECC_HashContext *hash_context, uint8_t *K, uint8_t *V) {
     HMAC_init(hash_context, K);
     HMAC_update(hash_context, V, hash_context->result_size);
     HMAC_finish(hash_context, K, V);
@@ -1281,7 +1283,7 @@ static void update_V(uECC_HashContext *hash_context, uint8_t *K, uint8_t *V) {
 int uECC_sign_deterministic(const uint8_t *private_key,
                             const uint8_t *message_hash,
                             unsigned hash_size,
-                            uECC_HashContext *hash_context,
+                            const uECC_HashContext *hash_context,
                             uint8_t *signature,
                             uECC_Curve curve) {
     uint8_t *K = hash_context->tmp;

--- a/uECC.c
+++ b/uECC.c
@@ -172,7 +172,7 @@ static cmpresult_t uECC_vli_cmp_unsafe(const uECC_word_t *left,
 
 #if default_RNG_defined
 static uECC_RNG_Function g_rng_function = &default_RNG;
-#else 
+#else
 static uECC_RNG_Function g_rng_function = 0;
 #endif
 
@@ -292,7 +292,7 @@ uECC_VLI_API cmpresult_t uECC_vli_cmp(const uECC_word_t *left,
 uECC_VLI_API void uECC_vli_rshift1(uECC_word_t *vli, wordcount_t num_words) {
     uECC_word_t *end = vli;
     uECC_word_t carry = 0;
-    
+
     vli += num_words;
     while (vli-- > end) {
         uECC_word_t temp = *vli;
@@ -475,7 +475,7 @@ uECC_VLI_API void uECC_vli_square(uECC_word_t *result,
     uECC_word_t r2 = 0;
 
     wordcount_t i, k;
-    
+
     for (k = 0; k < num_words * 2 - 1; ++k) {
         uECC_word_t min = (k < num_words ? 0 : (k + 1) - num_words);
         for (i = min; i <= k && i <= k - i; ++i) {
@@ -490,7 +490,7 @@ uECC_VLI_API void uECC_vli_square(uECC_word_t *result,
         r1 = r2;
         r2 = 0;
     }
-    
+
     result[num_words * 2 - 1] = r0;
 }
 #endif /* !asm_square */
@@ -504,7 +504,7 @@ uECC_VLI_API void uECC_vli_square(uECC_word_t *result,
     uECC_vli_mult(result, left, left, num_words);
 }
 #endif /* uECC_ENABLE_VLI_API */
-    
+
 #endif /* uECC_SQUARE_FUNC */
 
 /* Computes result = (left + right) % mod.
@@ -546,7 +546,7 @@ uECC_VLI_API void uECC_vli_mmod(uECC_word_t *result,
     uECC_word_t tmp[2 * uECC_MAX_WORDS];
     uECC_word_t *v[2] = {tmp, product};
     uECC_word_t index;
-    
+
     /* Shift mod so its highest set bit is at the maximum position. */
     bitcount_t shift = (num_words * 2 * uECC_WORD_BITS) - uECC_vli_numBits(mod, num_words);
     wordcount_t word_shift = shift / uECC_WORD_BITS;
@@ -646,7 +646,7 @@ uECC_VLI_API void uECC_vli_modSquare_fast(uECC_word_t *result,
                                           uECC_Curve curve) {
     uECC_vli_modMult_fast(result, left, left, curve);
 }
-    
+
 #endif /* uECC_SQUARE_FUNC */
 
 #define EVEN(vli) (!(vli[0] & 1))
@@ -671,7 +671,7 @@ uECC_VLI_API void uECC_vli_modInv(uECC_word_t *result,
                                   wordcount_t num_words) {
     uECC_word_t a[uECC_MAX_WORDS], b[uECC_MAX_WORDS], u[uECC_MAX_WORDS], v[uECC_MAX_WORDS];
     cmpresult_t cmpResult;
-    
+
     if (uECC_vli_isZero(input, num_words)) {
         uECC_vli_clear(result, num_words);
         return;
@@ -770,14 +770,14 @@ static void XYcZ_add(uECC_word_t * X1,
     /* t1 = X1, t2 = Y1, t3 = X2, t4 = Y2 */
     uECC_word_t t5[uECC_MAX_WORDS];
     wordcount_t num_words = curve->num_words;
-    
+
     uECC_vli_modSub(t5, X2, X1, curve->p, num_words); /* t5 = x2 - x1 */
     uECC_vli_modSquare_fast(t5, t5, curve);                  /* t5 = (x2 - x1)^2 = A */
     uECC_vli_modMult_fast(X1, X1, t5, curve);                /* t1 = x1*A = B */
     uECC_vli_modMult_fast(X2, X2, t5, curve);                /* t3 = x2*A = C */
     uECC_vli_modSub(Y2, Y2, Y1, curve->p, num_words); /* t4 = y2 - y1 */
     uECC_vli_modSquare_fast(t5, Y2, curve);                  /* t5 = (y2 - y1)^2 = D */
-                                                        
+
     uECC_vli_modSub(t5, t5, X1, curve->p, num_words); /* t5 = D - B */
     uECC_vli_modSub(t5, t5, X2, curve->p, num_words); /* t5 = D - B - C = x3 */
     uECC_vli_modSub(X2, X2, X1, curve->p, num_words); /* t3 = C - B */
@@ -785,7 +785,7 @@ static void XYcZ_add(uECC_word_t * X1,
     uECC_vli_modSub(X2, X1, t5, curve->p, num_words); /* t3 = B - x3 */
     uECC_vli_modMult_fast(Y2, Y2, X2, curve);                /* t4 = (y2 - y1)*(B - x3) */
     uECC_vli_modSub(Y2, Y2, Y1, curve->p, num_words); /* t4 = y3 */
-    
+
     uECC_vli_set(X2, t5, num_words);
 }
 
@@ -803,30 +803,30 @@ static void XYcZ_addC(uECC_word_t * X1,
     uECC_word_t t6[uECC_MAX_WORDS];
     uECC_word_t t7[uECC_MAX_WORDS];
     wordcount_t num_words = curve->num_words;
-    
+
     uECC_vli_modSub(t5, X2, X1, curve->p, num_words); /* t5 = x2 - x1 */
     uECC_vli_modSquare_fast(t5, t5, curve);                  /* t5 = (x2 - x1)^2 = A */
     uECC_vli_modMult_fast(X1, X1, t5, curve);                /* t1 = x1*A = B */
     uECC_vli_modMult_fast(X2, X2, t5, curve);                /* t3 = x2*A = C */
     uECC_vli_modAdd(t5, Y2, Y1, curve->p, num_words); /* t5 = y2 + y1 */
     uECC_vli_modSub(Y2, Y2, Y1, curve->p, num_words); /* t4 = y2 - y1 */
-                                                        
+
     uECC_vli_modSub(t6, X2, X1, curve->p, num_words); /* t6 = C - B */
     uECC_vli_modMult_fast(Y1, Y1, t6, curve);                /* t2 = y1 * (C - B) = E */
     uECC_vli_modAdd(t6, X1, X2, curve->p, num_words); /* t6 = B + C */
     uECC_vli_modSquare_fast(X2, Y2, curve);                  /* t3 = (y2 - y1)^2 = D */
     uECC_vli_modSub(X2, X2, t6, curve->p, num_words); /* t3 = D - (B + C) = x3 */
-                                                        
+
     uECC_vli_modSub(t7, X1, X2, curve->p, num_words); /* t7 = B - x3 */
     uECC_vli_modMult_fast(Y2, Y2, t7, curve);                /* t4 = (y2 - y1)*(B - x3) */
     uECC_vli_modSub(Y2, Y2, Y1, curve->p, num_words); /* t4 = (y2 - y1)*(B - x3) - E = y3 */
-                                                        
+
     uECC_vli_modSquare_fast(t7, t5, curve);                  /* t7 = (y2 + y1)^2 = F */
     uECC_vli_modSub(t7, t7, t6, curve->p, num_words); /* t7 = F - (B + C) = x3' */
     uECC_vli_modSub(t6, t7, X1, curve->p, num_words); /* t6 = x3' - B */
     uECC_vli_modMult_fast(t6, t6, t5, curve);                /* t6 = (y2+y1)*(x3' - B) */
     uECC_vli_modSub(Y1, t6, Y1, curve->p, num_words); /* t2 = (y2+y1)*(x3' - B) - E = y3' */
-    
+
     uECC_vli_set(X1, t7, num_words);
 }
 
@@ -844,7 +844,7 @@ static void EccPoint_mult(uECC_word_t * result,
     bitcount_t i;
     uECC_word_t nb;
     wordcount_t num_words = curve->num_words;
-    
+
     uECC_vli_set(Rx[1], point, num_words);
     uECC_vli_set(Ry[1], point + num_words, num_words);
 
@@ -858,20 +858,20 @@ static void EccPoint_mult(uECC_word_t * result,
 
     nb = !uECC_vli_testBit(scalar, 0);
     XYcZ_addC(Rx[1 - nb], Ry[1 - nb], Rx[nb], Ry[nb], curve);
-    
+
     /* Find final 1/Z value. */
     uECC_vli_modSub(z, Rx[1], Rx[0], curve->p, num_words); /* X1 - X0 */
     uECC_vli_modMult_fast(z, z, Ry[1 - nb], curve);               /* Yb * (X1 - X0) */
     uECC_vli_modMult_fast(z, z, point, curve);                    /* xP * Yb * (X1 - X0) */
     uECC_vli_modInv(z, z, curve->p, num_words);            /* 1 / (xP * Yb * (X1 - X0)) */
     /* yP / (xP * Yb * (X1 - X0)) */
-    uECC_vli_modMult_fast(z, z, point + num_words, curve); 
+    uECC_vli_modMult_fast(z, z, point + num_words, curve);
     uECC_vli_modMult_fast(z, z, Rx[1 - nb], curve); /* Xb * yP / (xP * Yb * (X1 - X0)) */
     /* End 1/Z calculation */
 
     XYcZ_add(Rx[nb], Ry[nb], Rx[1 - nb], Ry[1 - nb], curve);
     apply_z(Rx[0], Ry[0], z, curve);
-    
+
     uECC_vli_set(result, Rx[0], num_words);
     uECC_vli_set(result + num_words, Ry[0], num_words);
 }
@@ -945,7 +945,7 @@ uECC_VLI_API void uECC_vli_bytesToNative(uECC_word_t *native,
     uECC_vli_clear(native, (num_bytes + (uECC_WORD_SIZE - 1)) / uECC_WORD_SIZE);
     for (i = 0; i < num_bytes; ++i) {
         unsigned b = num_bytes - 1 - i;
-        native[b / uECC_WORD_SIZE] |= 
+        native[b / uECC_WORD_SIZE] |=
             (uECC_word_t)bytes[i] << (8 * (b % uECC_WORD_SIZE));
     }
 }
@@ -1013,15 +1013,15 @@ int uECC_shared_secret(const uint8_t *public_key,
     uECC_word_t carry;
     wordcount_t num_words = curve->num_words;
     wordcount_t num_bytes = curve->num_bytes;
-    
+
     uECC_vli_bytesToNative(private, private_key, BITS_TO_BYTES(curve->num_n_bits));
     uECC_vli_bytesToNative(public, public_key, num_bytes);
     uECC_vli_bytesToNative(public + num_words, public_key + num_bytes, num_bytes);
-    
+
     /* Regularize the bitcount for the private key so that attackers cannot use a side channel
        attack to learn the number of leading zeros. */
     carry = regularize_k(private, private, tmp, curve);
-    
+
     /* If an RNG function was specified, try to get a random initial Z value to improve
        protection against side-channel attacks. */
     if (g_rng_function) {
@@ -1030,7 +1030,7 @@ int uECC_shared_secret(const uint8_t *public_key,
         }
         initial_Z = p2[carry];
     }
-    
+
     EccPoint_mult(public, public, p2[!carry], initial_Z, curve->num_n_bits + 1, curve);
     uECC_vli_nativeToBytes(secret, num_bytes, public);
     return !EccPoint_isZero(public, curve);
@@ -1051,11 +1051,11 @@ void uECC_decompress(const uint8_t *compressed, uint8_t *public_key, uECC_Curve 
     uECC_vli_bytesToNative(point, compressed + 1, curve->num_bytes);
     curve->x_side(y, point, curve);
     curve->mod_sqrt(y, curve);
-    
+
     if ((y[0] & 0x01) != (compressed[0] & 0x01)) {
         uECC_vli_sub(y, curve->p, y, curve->num_words);
     }
-    
+
     uECC_vli_nativeToBytes(public_key, curve->num_bytes, point);
     uECC_vli_nativeToBytes(public_key + curve->num_bytes, curve->num_bytes, y);
 }
@@ -1070,16 +1070,16 @@ int uECC_valid_point(const uECC_word_t *point, uECC_Curve curve) {
     if (EccPoint_isZero(point, curve)) {
         return 0;
     }
-    
+
     /* x and y must be smaller than p. */
     if (uECC_vli_cmp_unsafe(curve->p, point, num_words) != 1 ||
             uECC_vli_cmp_unsafe(curve->p, point + num_words, num_words) != 1) {
         return 0;
     }
-    
+
     uECC_vli_modSquare_fast(tmp1, point + num_words, curve);
     curve->x_side(tmp2, point, curve); /* tmp2 = x^3 + ax + b */
-    
+
     /* Make sure that y^2 == x^3 + ax + b */
     return (int)(uECC_vli_equal(tmp1, tmp2, num_words));
 }
@@ -1165,18 +1165,18 @@ static int uECC_sign_with_k(const uint8_t *private_key,
     wordcount_t num_words = curve->num_words;
     wordcount_t num_n_words = BITS_TO_WORDS(curve->num_n_bits);
     bitcount_t num_n_bits = curve->num_n_bits;
-    
+
     /* Make sure 0 < k < curve_n */
     if (uECC_vli_isZero(k, num_words) || uECC_vli_cmp(curve->n, k, num_n_words) != 1) {
         return 0;
     }
-    
+
     carry = regularize_k(k, tmp, s, curve);
     EccPoint_mult(p, curve->G, k2[!carry], 0, num_n_bits + 1, curve);
     if (uECC_vli_isZero(p, num_words)) {
         return 0;
     }
-    
+
     /* If an RNG function was specified, get a random number
        to prevent side channel analysis of k. */
     if (!g_rng_function) {
@@ -1191,9 +1191,9 @@ static int uECC_sign_with_k(const uint8_t *private_key,
     uECC_vli_modMult(k, k, tmp, curve->n, num_n_words); /* k' = rand * k */
     uECC_vli_modInv(k, k, curve->n, num_n_words);       /* k = 1 / k' */
     uECC_vli_modMult(k, k, tmp, curve->n, num_n_words); /* k = 1 / k */
-    
+
     uECC_vli_nativeToBytes(signature, curve->num_bytes, p); /* store r */
-    
+
     uECC_vli_bytesToNative(tmp, private_key, BITS_TO_BYTES(curve->num_n_bits)); /* tmp = d */
     s[num_n_words - 1] = 0;
     uECC_vli_set(s, p, num_words);
@@ -1295,7 +1295,7 @@ int uECC_sign_deterministic(const uint8_t *private_key,
         V[i] = 0x01;
         K[i] = 0;
     }
-    
+
     /* K = HMAC_K(V || 0x00 || int2octets(x) || h(m)) */
     HMAC_init(hash_context, K);
     V[hash_context->result_size] = 0x00;
@@ -1305,7 +1305,7 @@ int uECC_sign_deterministic(const uint8_t *private_key,
     HMAC_finish(hash_context, K, K);
 
     update_V(hash_context, K, V);
-    
+
     /* K = HMAC_K(V || 0x01 || int2octets(x) || h(m)) */
     HMAC_init(hash_context, K);
     V[hash_context->result_size] = 0x01;
@@ -1335,7 +1335,7 @@ int uECC_sign_deterministic(const uint8_t *private_key,
             T[num_n_words - 1] &=
                 mask >> ((bitcount_t)(num_n_words * uECC_WORD_SIZE * 8 - num_n_bits));
         }
-    
+
         if (uECC_sign_with_k(private_key, message_hash, hash_size, T, signature, curve)) {
             return 1;
         }
@@ -1376,7 +1376,7 @@ int uECC_verify(const uint8_t *public_key,
     uECC_word_t r[uECC_MAX_WORDS], s[uECC_MAX_WORDS];
     wordcount_t num_words = curve->num_words;
     wordcount_t num_n_words = BITS_TO_WORDS(curve->num_n_bits);
-    
+
     rx[num_n_words - 1] = 0;
     r[num_n_words - 1] = 0;
     s[num_n_words - 1] = 0;
@@ -1386,7 +1386,7 @@ int uECC_verify(const uint8_t *public_key,
         public + num_words, public_key + curve->num_bytes, curve->num_bytes);
     uECC_vli_bytesToNative(r, signature, curve->num_bytes);
     uECC_vli_bytesToNative(s, signature + curve->num_bytes, curve->num_bytes);
-    
+
     /* r, s must not be 0. */
     if (uECC_vli_isZero(r, num_words) || uECC_vli_isZero(s, num_words)) {
         return 0;
@@ -1404,7 +1404,7 @@ int uECC_verify(const uint8_t *public_key,
     bits2int(u1, message_hash, hash_size, curve);
     uECC_vli_modMult(u1, u1, z, curve->n, num_n_words); /* u1 = e/s */
     uECC_vli_modMult(u2, r, z, curve->n, num_n_words); /* u2 = r/s */
-    
+
     /* Calculate sum = G + Q. */
     uECC_vli_set(sum, public, num_words);
     uECC_vli_set(sum + num_words, public + num_words, num_words);
@@ -1414,7 +1414,7 @@ int uECC_verify(const uint8_t *public_key,
     XYcZ_add(tx, ty, sum, sum + num_words, curve);
     uECC_vli_modInv(z, z, curve->p, num_words); /* z = 1/z */
     apply_z(sum, sum + num_words, z, curve);
-    
+
     /* Use Shamir's trick to calculate u1*G + u2*Q */
     points[0] = 0;
     points[1] = curve->G;
@@ -1422,7 +1422,7 @@ int uECC_verify(const uint8_t *public_key,
     points[3] = sum;
     num_bits = smax(uECC_vli_numBits(u1, num_n_words),
                     uECC_vli_numBits(u2, num_n_words));
-    
+
     point = points[(!!uECC_vli_testBit(u1, num_bits - 1)) |
                    ((!!uECC_vli_testBit(u2, num_bits - 1)) << 1)];
     uECC_vli_set(rx, point, num_words);
@@ -1433,7 +1433,7 @@ int uECC_verify(const uint8_t *public_key,
     for (i = num_bits - 2; i >= 0; --i) {
         uECC_word_t index;
         curve->double_jacobian(rx, ry, z, curve);
-        
+
         index = (!!uECC_vli_testBit(u1, i)) | ((!!uECC_vli_testBit(u2, i)) << 1);
         point = points[index];
         if (point) {
@@ -1448,7 +1448,7 @@ int uECC_verify(const uint8_t *public_key,
 
     uECC_vli_modInv(z, z, curve->p, num_words); /* Z = 1/Z */
     apply_z(rx, ry, z, curve);
-    
+
     /* v = x1 (mod n) */
     if (uECC_vli_cmp_unsafe(curve->n, rx, num_n_words) != 1) {
         uECC_vli_sub(rx, rx, curve->n, num_n_words);

--- a/uECC.h
+++ b/uECC.h
@@ -317,7 +317,7 @@ Inputs:
 
 Returns 1 if the signature is valid, 0 if it is invalid.
 */
-int uECC_verify(const uint8_t *private_key,
+int uECC_verify(const uint8_t *public_key,
                 const uint8_t *message_hash,
                 unsigned hash_size,
                 const uint8_t *signature,

--- a/uECC.h
+++ b/uECC.h
@@ -122,8 +122,8 @@ Outputs:
     private_key - Will be filled in with the private key. Must be as long as the curve order; this
                   is typically the same as the curve size, except for secp160r1. For example, if the
                   curve is secp256r1, private_key must be 32 bytes long.
-                  
-                  For secp160r1, private_key must be 21 bytes long! Note that the first byte will 
+
+                  For secp160r1, private_key must be 21 bytes long! Note that the first byte will
                   almost always be 0 (there is about a 1 in 2^80 chance of it being non-zero).
 
 Returns 1 if the key pair was generated successfully, 0 if an error occurred.

--- a/uECC.h
+++ b/uECC.h
@@ -265,11 +265,11 @@ void finish_SHA256(uECC_HashContext *base, uint8_t *hash_result) {
 }
 */
 typedef struct uECC_HashContext {
-    void (*init_hash)(struct uECC_HashContext *context);
-    void (*update_hash)(struct uECC_HashContext *context,
+    void (*init_hash)(const struct uECC_HashContext *context);
+    void (*update_hash)(const struct uECC_HashContext *context,
                         const uint8_t *message,
                         unsigned message_size);
-    void (*finish_hash)(struct uECC_HashContext *context, uint8_t *hash_result);
+    void (*finish_hash)(const struct uECC_HashContext *context, uint8_t *hash_result);
     unsigned block_size; /* Hash function block size in bytes, eg 64 for SHA-256. */
     unsigned result_size; /* Hash function result size in bytes, eg 32 for SHA-256. */
     uint8_t *tmp; /* Must point to a buffer of at least (2 * result_size + block_size) bytes. */
@@ -299,7 +299,7 @@ Returns 1 if the signature generated successfully, 0 if an error occurred.
 int uECC_sign_deterministic(const uint8_t *private_key,
                             const uint8_t *message_hash,
                             unsigned hash_size,
-                            uECC_HashContext *hash_context,
+                            const uECC_HashContext *hash_context,
                             uint8_t *signature,
                             uECC_Curve curve);
 


### PR DESCRIPTION
I think the only possibly controversial change here will be the move to const for uECC_HashContext.  It
provides important information regarding being able to reuse the same context repeatedly (as is done
in the test_ecdsa_deterministic) without digging through source code to verify but does complicate
the callbacks slightly if needing to remove the const to access some surrounding struct (as is done
in the test_ecdsa_deterministic).

Definitely recommend looking at the individual commit diffs rather than the combined one on the pull request.