### PR TITLE
fix compile of test/test_ecdsa_deterministic on OS X

### DIFF
--- a/emk_project.py
+++ b/emk_project.py
@@ -47,7 +47,7 @@ def setup_osx():
     c.cxx.flags += ["-stdlib=libc++"]
     link.cxx.flags += ["-stdlib=libc++"]
 
-    link_flags = [("-arch", "x86_64")]
+    link_flags = [("-arch", "x86_64", "-lcrypto")]
     link.local_flags.extend(link_flags)
 
 def setup_avr():


### PR DESCRIPTION
The test uses SHA256 from openssl. This changes adds -lcryto to the ldflags

Error without the fix:
    Undefined symbols for architecture x86_64:
      "_SHA256_Final", referenced from:
          _finish_SHA256 in test_ecdsa_deterministic.o
      "_SHA256_Init", referenced from:
          _init_SHA256 in test_ecdsa_deterministic.o
      "_SHA256_Update", referenced from:
          _update_SHA256 in test_ecdsa_deterministic.o
    ld: symbol(s) not found for architecture x86_64
    clang: error: linker command failed with exit code 1 (use -v to see invocation)