### PR TITLE
Fix/armeabi compile error

### DIFF
--- a/uECC.c
+++ b/uECC.c
@@ -172,7 +172,7 @@ static cmpresult_t uECC_vli_cmp_unsafe(const uECC_word_t *left,
                                        const uECC_word_t *right,
                                        wordcount_t num_words);
 
-#if defined( __arm__ ) && !defined( __ARM_ARCH_7A__ )
+#if defined( __arm__ ) && !defined( __ARM_ARCH_7A__ ) && !defined( __ARM_ARCH_7R__ ) && !defined( __ARM_ARCH_7M__ ) && !defined( __ARM_ARCH_7S__ )
 #define ARM_THUMB_NOT_SUPPORTED
 #endif
 

--- a/uECC.c
+++ b/uECC.c
@@ -172,8 +172,11 @@ static cmpresult_t uECC_vli_cmp_unsafe(const uECC_word_t *left,
                                        const uECC_word_t *right,
                                        wordcount_t num_words);
 
-#if (uECC_PLATFORM == uECC_arm || uECC_PLATFORM == uECC_arm_thumb || \
-        uECC_PLATFORM == uECC_arm_thumb2)
+#if defined( __arm__ ) && !defined( __ARM_ARCH_7A__ )
+#define ARM_THUMB_NOT_SUPPORTED
+#endif
+
+#if ( (uECC_PLATFORM == uECC_arm || uECC_PLATFORM == uECC_arm_thumb || uECC_PLATFORM == uECC_arm_thumb2) && !defined( ARM_THUMB_NOT_SUPPORTED ) )
     #include "asm_arm.inc"
 #endif
 


### PR DESCRIPTION
Fix compile error when building for Android armeabi.

There are illegal instructions errors when compiling the default code for armeabi, so I disabled using of assembly for this ABI and ensure C code is used.

This is not the most efficient, but armeabi Android devices are rare today (production of them stopped around 2012), so this is only a quick fix to enable compiling.

If you have suggestions how this can be improved, please let me know.