### PR TITLE
Add hint to example RNG function.

### DIFF
--- a/examples/ecc_test/ecc_test.ino
+++ b/examples/ecc_test/ecc_test.ino
@@ -6,6 +6,7 @@ static int RNG(uint8_t *dest, unsigned size) {
   // Use the least-significant bits from the ADC for an unconnected pin (or connected to a source of 
   // random noise). This can take a long time to generate random data if the result of analogRead(0) 
   // doesn't change very frequently.
+  // HINT: You can speed this up considerably by adding a wire (e.g. 10cm) to the A0 pin as an antenna.
   while (size) {
     uint8_t val = 0;
     for (unsigned i = 0; i < 8; ++i) {


### PR DESCRIPTION
I found a neat little trick to speed up the example, by adding a simple antenna/ wire to A0.
In my case the key generation speeds from up to 390s down to nearly constant 2.5s on an Atmega328p at 8Mhz.
