### PR TITLE
platform-specific.inc: add support for RIOT-OS

### DIFF
--- a/platform-specific.inc
+++ b/platform-specific.inc
@@ -66,6 +66,16 @@ static int default_RNG(uint8_t *dest, unsigned size) {
 }
 #define default_RNG_defined 1
 
+#elif defined(RIOT_VERSION)
+
+#include <random.h>
+
+static int default_RNG(uint8_t *dest, unsigned size) {
+    random_bytes(dest, size);
+    return 1;
+}
+#define default_RNG_defined 1
+
 #endif /* platform */
 
 #endif /* _UECC_PLATFORM_SPECIFIC_H_ */


### PR DESCRIPTION
Add support for [RIOT-OS](https://github.com/RIOT-OS/RIOT) to libhydrogen so we can just use the upstream version in the [RIOT `pkg`](https://github.com/RIOT-OS/RIOT/tree/master/pkg/micro-ecc).