### PR TITLE
Add RNG for nRF52 series

### DIFF
--- a/platform-specific.inc
+++ b/platform-specific.inc
@@ -76,6 +76,19 @@ static int default_RNG(uint8_t *dest, unsigned size) {
 }
 #define default_RNG_defined 1
 
+#elif defined(NRF52_SERIES)
+
+#include "app_error.h"
+#include "nrf_crypto_rng.h"
+
+static int default_RNG(uint8_t *dest, unsigned size) 
+{
+    // make sure to call nrf_crypto_init and nrf_crypto_rng_init first
+    ret_code_t ret_code = nrf_crypto_rng_vector_generate(dest, size);
+    return (ret_code == NRF_SUCCESS) ? 1 : 0;
+}
+#define default_RNG_defined 1
+
 #endif /* platform */
 
 #endif /* _UECC_PLATFORM_SPECIFIC_H_ */

--- a/uECC.c
+++ b/uECC.c
@@ -994,7 +994,7 @@ uECC_VLI_API void uECC_vli_bytesToNative(uint8_t *native,
 uECC_VLI_API void uECC_vli_nativeToBytes(uint8_t *bytes,
                                          int num_bytes,
                                          const uECC_word_t *native) {
-    wordcount_t i;
+    int i;
     for (i = 0; i < num_bytes; ++i) {
         unsigned b = num_bytes - 1 - i;
         bytes[i] = native[b / uECC_WORD_SIZE] >> (8 * (b % uECC_WORD_SIZE));
@@ -1004,7 +1004,7 @@ uECC_VLI_API void uECC_vli_nativeToBytes(uint8_t *bytes,
 uECC_VLI_API void uECC_vli_bytesToNative(uECC_word_t *native,
                                          const uint8_t *bytes,
                                          int num_bytes) {
-    wordcount_t i;
+    int i;
     uECC_vli_clear(native, (num_bytes + (uECC_WORD_SIZE - 1)) / uECC_WORD_SIZE);
     for (i = 0; i < num_bytes; ++i) {
         unsigned b = num_bytes - 1 - i;


### PR DESCRIPTION
Also: Fixed infinite for loop because of int - wordcount_t mismatch

The other solution would be to make wordcount_t something larger than int8_t

For whatever reason num_bytes was >= 128 and the for loop became an infinite loop because of the limited range of int8_t (luckily a compiler warning was generated)