### PR TITLE
uECC_vli_mmod: Avoid potential buffer overrun

### DIFF
--- a/uECC.c
+++ b/uECC.c
@@ -582,12 +582,12 @@ uECC_VLI_API void uECC_vli_mmod(uECC_word_t *result,
     uECC_word_t carry = 0;
     uECC_vli_clear(mod_multiple, word_shift);
     if (bit_shift > 0) {
-        for(index = 0; index < (uECC_word_t)num_words; ++index) {
+        for(index = 0; word_shift + index < (uECC_word_t)(num_words * 2); ++index) {
             mod_multiple[word_shift + index] = (mod[index] << bit_shift) | carry;
             carry = mod[index] >> (uECC_WORD_BITS - bit_shift);
         }
     } else {
-        uECC_vli_set(mod_multiple + word_shift, mod, num_words);
+        uECC_vli_set(mod_multiple + word_shift, mod, (num_words * 2) - word_shift);
     }
 
     for (index = 1; shift >= 0; --shift) {


### PR DESCRIPTION
The shifting copy of `mod` into `mod_multiple` would overrun the destination if the high word of `mod` was zero, so `word_shift` > `num_words`.

This is not the case for any curve p or n, but this part of the code is written as if to support arbitrary `mod`, comment disclaimer notwithstanding.

Issue was detected via a static analysis tool.

Alternative would be to reduce the genericness and just use `vli_numDigits` on the high word to get `bit_shift`, and use `num_words` as `word_shift`.