### PR TITLE
Updates .gitignore to ignore *.a, *.o, and *.so

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,7 @@ __pycache__
 *.pyd
 *.pyz
 *.egg-info/
+*.a
+*.o
+*.so
 .DS_Store


### PR DESCRIPTION
This just adds three file extensions to .gitignore to prevent library binaries from bing added to the repo.