### PR TITLE
Never inline uECC_vli_add/sub/clear.

### DIFF
--- a/asm_arm.inc
+++ b/asm_arm.inc
@@ -43,6 +43,7 @@
 
 #if (uECC_OPTIMIZATION_LEVEL >= 2)
 
+__attribute__((noinline))
 uECC_VLI_API uECC_word_t uECC_vli_add(uECC_word_t *result,
                                       const uECC_word_t *left,
                                       const uECC_word_t *right,
@@ -97,6 +98,7 @@ uECC_VLI_API uECC_word_t uECC_vli_add(uECC_word_t *result,
 }
 #define asm_add 1
 
+__attribute__((noinline))
 uECC_VLI_API uECC_word_t uECC_vli_sub(uECC_word_t *result,
                                       const uECC_word_t *left,
                                       const uECC_word_t *right,

--- a/uECC.c
+++ b/uECC.c
@@ -209,6 +209,7 @@ int uECC_curve_public_key_size(uECC_Curve curve) {
 }
 
 #if !asm_clear
+__attribute__((noinline))
 uECC_VLI_API void uECC_vli_clear(uECC_word_t *vli, wordcount_t num_words) {
     wordcount_t i;
     for (i = 0; i < num_words; ++i) {


### PR DESCRIPTION
Clang will unconditionally inline these large assembly functions at -Oz. This should be addressed upstream, but in the meantime, we can save some kilobytes by forcing them to never be inlined.