### PR TITLE
Bug calculation carry/borrow when right=0xFFFFFFFF and carry/borrow=1

### DIFF
--- a/uECC.c
+++ b/uECC.c
@@ -340,9 +340,7 @@ uECC_VLI_API uECC_word_t uECC_vli_add(uECC_word_t *result,
     wordcount_t i;
     for (i = 0; i < num_words; ++i) {
         uECC_word_t sum = left[i] + right[i] + carry;
-        if (sum != left[i]) {
-            carry = (sum < left[i]);
-        }
+        carry = ((sum-carry) < left[i]);
         result[i] = sum;
     }
     return carry;
@@ -359,9 +357,7 @@ uECC_VLI_API uECC_word_t uECC_vli_sub(uECC_word_t *result,
     wordcount_t i;
     for (i = 0; i < num_words; ++i) {
         uECC_word_t diff = left[i] - right[i] - borrow;
-        if (diff != left[i]) {
-            borrow = (diff > left[i]);
-        }
+        borrow = ( (diff+borrow) > left[i]);
         result[i] = diff;
     }
     return borrow;


### PR DESCRIPTION
Bug in uECC_vli_add and uECC_vli_sub

Error appear when oper2 = 0xFFFFFFFF and previous carry=1

i.e with 8 bits:  
<pre>
oper1:       83 +
oper2:       FF
           ------
   F+3=      12
 1+8+F=     18   // carry = (sum < left[i])  -->  carry = (8<8)  --> carry = 0 (Incorrect)
           ------
            182  //  Correct result
</pre>

Equivalent error appears in the calculation of borrow in uECC_vli_sub

         
             
                  

