### PR TITLE
asm_avr.inc: fix compilation on GCC 15.2.0

### DIFF
--- a/asm_avr.inc
+++ b/asm_avr.inc
@@ -905,12 +905,17 @@ uECC_VLI_API void uECC_vli_mult(uECC_word_t *result,
                                 const uECC_word_t *left,
                                 const uECC_word_t *right,
                                 wordcount_t num_words) {
-    volatile uECC_word_t *r = result;
     uint8_t r0 = 0;
     uint8_t r1 = 0;
     uint8_t r2 = 0;
     uint8_t zero = 0;
     uint8_t k, i;
+
+    /* manually allocate right to register Y to work around bug in GCC 15.2 */
+    register uint8_t yl asm("r28");
+    register uint8_t yh asm("r29");
+    yl = (uint8_t)(unsigned)right;
+    yh = (uint8_t)(((unsigned)right) >> 8);
 
     __asm__ volatile (
         "ldi %[k], 1 \n\t" /* k = 1; k < num_words; ++k */
@@ -986,7 +991,7 @@ uECC_VLI_API void uECC_vli_mult(uECC_word_t *result,
         "st z+, %[r0] \n\t"  /* Store last result byte. */
         "eor r1, r1 \n\t" /* fix r1 to be 0 again */
 
-        : "+z" (result), "+x" (left), "+y" (right),
+        : "+z" (result), "+x" (left), "+r" (yl), "+r" (yh),
           [r0] "+r" (r0), [r1] "+r" (r1), [r2] "+r" (r2),
           [zero] "+r" (zero), [num] "+r" (num_words),
           [k] "=&r" (k), [i] "=&r" (i)


### PR DESCRIPTION
Compilation with GCC 15.2.0 failed with:

    asm_avr.inc:915:5: error: cannot find a register in class 'POINTER_Y_REGS' while reloading 'asm'

This works around the issue by manually placing right into the Y register before the inline assembly.

The generated assembly from the function is almost perfectly identical. [Here is a side-by-side comparison](https://godbolt.org/z/YGbs7jc6r). Basically the old code prepared first the Z register, then the Y register, the new code swaps the order. Otherwise the generated code is identical.